### PR TITLE
Added public workspace edge case support

### DIFF
--- a/zegami_sdk/client.py
+++ b/zegami_sdk/client.py
@@ -5,7 +5,7 @@ Apache 2.0
 """
 
 
-from .workspace import Workspace
+from .workspace import Workspace, PublicWorkspace
 from .util import (
     _auth_get,
     _auth_post,
@@ -126,7 +126,8 @@ class ZegamiClient():
         
         url = '{}/oauth/userinfo/'.format(self.HOME)
         self._user_info = self._auth_get(url)
-        self._workspaces = [Workspace(self, w) for w in self._user_info['projects']]
+        self._workspaces = [PublicWorkspace(self)]
+        self._workspaces += [Workspace(self, w) for w in self._user_info['projects']]
         
         
         

--- a/zegami_sdk/workspace.py
+++ b/zegami_sdk/workspace.py
@@ -94,10 +94,7 @@ class PublicWorkspace(Workspace):
         super().__init__(client, {
             'created' : 'N/A',
             'creator_tenant_slug' : 'N/A',
-            'features' : ['automatic_data_clustering',
-                          'automatic_image_clustering',
-                          'image_resize',
-                          'use_new_creation_ui'],
+            'features' : [],
             'id' : 'public',
             'name' : 'public',
             'roles' : [],

--- a/zegami_sdk/workspace.py
+++ b/zegami_sdk/workspace.py
@@ -14,10 +14,6 @@ class Workspace():
         self._data = workspace_dict
         self._check_data()
         
-        
-
-    def __repr__(self):
-        return "<Workspace id={} name={}>".format(self.id, self.name)
 
     @property
     def id(): pass
@@ -83,3 +79,51 @@ class Workspace():
             
     def __len__(self):
         len(self.collections)
+        
+
+    def __repr__(self):
+        return "<Workspace id={} name={}>".format(self.id, self.name)
+    
+    
+    
+class PublicWorkspace(Workspace):
+    ''' The public workspace is an edge case, and some information is not
+    available. '''
+    
+    def __init__(self, client):
+        super().__init__(client, {
+            'created' : 'N/A',
+            'creator_tenant_slug' : 'N/A',
+            'features' : ['automatic_data_clustering',
+                          'automatic_image_clustering',
+                          'image_resize',
+                          'use_new_creation_ui'],
+            'id' : 'public',
+            'name' : 'public',
+            'roles' : [],
+            'storage_location' : 'AZ_North_Europe',
+            'subscription_level' : None,
+            'updated' : None
+        })
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        
+        


### PR DESCRIPTION
Added support for the public workspace using a PublicWorkspace(Workspace) child.
Can be called using `zc.get_workspace_by_<name | id>('public')`