### PR TITLE
Remove public workspaces

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='zegami-sdk',
-    version='0.2.3',
+    version='0.2.4',
     description='A suite of tools for interacting with Zegami through Python.',
     long_description=README,
     long_description_content_type='text/markdown',

--- a/zegami_sdk/client.py
+++ b/zegami_sdk/client.py
@@ -5,7 +5,7 @@ Apache 2.0
 """
 
 
-from .workspace import Workspace, PublicWorkspace
+from .workspace import Workspace
 from .util import (
     _auth_get,
     _auth_post,
@@ -126,8 +126,7 @@ class ZegamiClient():
         
         url = '{}/oauth/userinfo/'.format(self.HOME)
         self._user_info = self._auth_get(url)
-        self._workspaces = [PublicWorkspace(self)]
-        self._workspaces += [Workspace(self, w) for w in self._user_info['projects']]
+        self._workspaces = [Workspace(self, w) for w in self._user_info['projects']]
         
         
         

--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -364,18 +364,29 @@ class Collection():
     
     
     def _join_id_to_lookup(self, join_id) -> list:
-        assert type(join_id) == str, 'Expected join_id to be string: {}'.format(join_id)
         c = self.client
+        assert type(join_id) == str, 'Expected join_id to be string: {}'.format(join_id)
         url = '{}/{}/project/{}/datasets/{}'.format(c.HOME, c.API_0, self.workspace_id, join_id)
-        return c._auth_get(url)['dataset']['imageset_indices']
+        dataset = c._auth_get(url)['dataset']
+        assert 'imageset_indices' in dataset.keys(), 'No \'imageset_indices\' '\
+            'in obtained dataset: {}'.format(dataset.keys())
+            
+        return dataset['imageset_indices']
     
     
     def _get_image_meta_lookup(self, source=0) -> list:
         if self.allow_caching and self._cached_image_meta_lookup:
             self._check_data()
-        assert 'imageset_dataset_join_id' in self._data.keys(),\
-            'Collection\'s data didn\'t have an \'imageset_dataset_join_id\' key'
-        join_id = self._data['imageset_dataset_join_id']
+            
+        keys = ['imageset_dataset_join_id', 'join_dataset_id']
+        assert keys[0] in self._data.keys() or keys[1] in self._data.keys(),\
+            'Collection\'s data didn\'t contain one of: {}'.format(keys)
+            
+        try:
+            join_id = self._data[keys[0]]
+        except:
+            join_id = self._data[keys[1]]
+        
         return self._join_id_to_lookup(join_id)
     
     

--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -378,14 +378,11 @@ class Collection():
         if self.allow_caching and self._cached_image_meta_lookup:
             self._check_data()
             
-        keys = ['imageset_dataset_join_id', 'join_dataset_id']
-        assert keys[0] in self._data.keys() or keys[1] in self._data.keys(),\
-            'Collection\'s data didn\'t contain one of: {}'.format(keys)
-            
-        try:
-            join_id = self._data[keys[0]]
-        except:
-            join_id = self._data[keys[1]]
+        key = 'imageset_dataset_join_id'
+        assert key in self._data.keys(),\
+            'Collection\'s data didn\'t contain \'{}\''.format(key)
+           
+        join_id = self._data[key]
         
         return self._join_id_to_lookup(join_id)
     

--- a/zegami_sdk/workspace.py
+++ b/zegami_sdk/workspace.py
@@ -83,25 +83,6 @@ class Workspace():
 
     def __repr__(self):
         return "<Workspace id={} name={}>".format(self.id, self.name)
-    
-    
-    
-class PublicWorkspace(Workspace):
-    ''' The public workspace is an edge case, and some information is not
-    available. '''
-    
-    def __init__(self, client):
-        super().__init__(client, {
-            'created' : 'N/A',
-            'creator_tenant_slug' : 'N/A',
-            'features' : [],
-            'id' : 'public',
-            'name' : 'public',
-            'roles' : [],
-            'storage_location' : 'AZ_North_Europe',
-            'subscription_level' : None,
-            'updated' : None
-        })
         
         
         


### PR DESCRIPTION
After consideration, removed public workspaces. Likely to be deprecated in future, and public workspaces do not have the same data structure as regular ones. Users will be expected to use the SDK on their own private work.