### PR TITLE
Correct fallback mime type for binary data

### DIFF
--- a/zegami_sdk/workspace.py
+++ b/zegami_sdk/workspace.py
@@ -95,7 +95,7 @@ class Workspace():
             try:
                 mime_type = magic.from_buffer(data, mime=True)
             except TypeError:
-                mime_type = 'application/octet'
+                mime_type = 'application/octet-stream'
 
         # get signed url to use signature
         client = self._client


### PR DESCRIPTION
RFC 2046 [defines specifically `application/octet-stream` for arbitrary binary data](https://datatracker.ietf.org/doc/html/rfc2046#section-4.5.1) - just updating to match, else for things that care this could cause headaches.