### PR TITLE
Use a session object to manage requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,9 @@ numpy
 pandas
 pathlib
 Pillow
-requests=2.26.0
+requests==2.26.0
 twine
 xlrd
 libmagic
 tqdm
-urllib=1.26.6
+urllib==1.26.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ twine
 xlrd
 libmagic
 tqdm
-urllib==1.26.6
+urllib3==1.26.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,9 @@ numpy
 pandas
 pathlib
 Pillow
-requests
+requests=2.26.0
 twine
 xlrd
 libmagic
 tqdm
+urllib=1.26.6

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,6 @@ setup(
         'colorama',
         'importlib-metadata',
         'keyring',
-        'twine',
         'pathlib',
         'numpy',
         'pandas',
@@ -49,6 +48,7 @@ setup(
         'requests',
         'tqdm',
         'xlrd',
+        'urllib3'
     ],
     python_requires='>=3.6'
 )

--- a/zegami_sdk/client.py
+++ b/zegami_sdk/client.py
@@ -11,6 +11,7 @@ from .util import (
     _auth_post,
     _auth_put,
     _auth_delete,
+    _create_session,
     _ensure_token,
     _get_token,
     _check_status,
@@ -43,15 +44,20 @@ class ZegamiClient():
     _auth_post = _auth_post
     _auth_put = _auth_put
     _auth_delete = _auth_delete
+    _create_session = _create_session
     _ensure_token = _ensure_token
     _get_token = classmethod(_get_token)
     _check_status = staticmethod(_check_status)
     _obtain_signed_blob_storage_urls = _obtain_signed_blob_storage_urls
     _upload_to_signed_blob_storage_url = staticmethod(_upload_to_signed_blob_storage_url)
+    _session = None
 
     def __init__(self, username=None, password=None, token=None, allow_save_token=True):
         # Make sure we have a token
         self._ensure_token(username, password, token, allow_save_token)
+
+        # Initialise a requests session
+        self.session = self.
 
         # Get user info, workspaces
         self._refresh_client()
@@ -61,17 +67,6 @@ class ZegamiClient():
             print('\nInitialized successfully, welcome {}.'.format(self.name.split(' ')[0]))
         except Exception:
             pass
-
-    @property
-    def headers():
-        pass
-
-    @headers.getter
-    def headers(self):
-        return {
-            'Authorization': 'Bearer {}'.format(self.token),
-            'Content-Type': 'application/json',
-        }
 
     @property
     def user_info():

--- a/zegami_sdk/client.py
+++ b/zegami_sdk/client.py
@@ -11,7 +11,8 @@ from .util import (
     _auth_post,
     _auth_put,
     _auth_delete,
-    _create_session,
+    _create_zegami_session,
+    _create_blobstore_session,
     _ensure_token,
     _get_token,
     _check_status,
@@ -44,20 +45,23 @@ class ZegamiClient():
     _auth_post = _auth_post
     _auth_put = _auth_put
     _auth_delete = _auth_delete
-    _create_session = _create_session
+    _create_zegami_session = _create_zegami_session
+    _create_blobstore_session = _create_blobstore_session
     _ensure_token = _ensure_token
     _get_token = classmethod(_get_token)
     _check_status = staticmethod(_check_status)
     _obtain_signed_blob_storage_urls = _obtain_signed_blob_storage_urls
-    _upload_to_signed_blob_storage_url = staticmethod(_upload_to_signed_blob_storage_url)
-    _session = None
+    _upload_to_signed_blob_storage_url = _upload_to_signed_blob_storage_url
+    _zegami_session = None
+    _blobstore_session = None
 
     def __init__(self, username=None, password=None, token=None, allow_save_token=True):
         # Make sure we have a token
         self._ensure_token(username, password, token, allow_save_token)
 
         # Initialise a requests session
-        self.session = self.
+        self._create_zegami_session()
+        self._create_blobstore_session()
 
         # Get user info, workspaces
         self._refresh_client()

--- a/zegami_sdk/source.py
+++ b/zegami_sdk/source.py
@@ -87,8 +87,8 @@ class Source():
             elif file_ext in self.IMAGE_MIMES.keys():
                 mime_type = self.IMAGE_MIMES[file_ext]
             else:
-                raise ValueError(
-                    f"File extension must be one of these: {' '.join([key for key in self.IMAGE_MIMES.keys()])}")
+                print("\n File is not a recognised type", file_name)
+                continue
 
             with open(path, 'rb') as f:
 
@@ -100,7 +100,10 @@ class Source():
                 try:
                     client._upload_to_signed_blob_storage_url(f, url, mime_type)
                 except Exception as ex:
-                    print('\nAn exception occurred: ', ex)
+                    # The upload will retry in the face of errors. This blob can't be uploaded ata ll
+                    # Continue on to the next image without including any image info
+                    print(f'\nAn error occurred while uploading image {path} to blob storage:', ex)
+                    continue
 
                 # update the new image details to the relevant endpoint
                 info = {

--- a/zegami_sdk/util.py
+++ b/zegami_sdk/util.py
@@ -10,14 +10,45 @@ from pathlib import Path
 import uuid
 
 import requests
+import urllib3
 
-def _create_session(self):
-    """Create a session object to ensure auth token is included as appropriate."""
+
+def __get_retry_adapter():
+    retry_methods = urllib3.util.retry.Retry.DEFAULT_METHOD_WHITELIST.union(
+        ('POST', 'PUT'))
+    retry = urllib3.util.retry.Retry(
+        total=10,
+        backoff_factor=0.5,
+        status_forcelist=[(502, 503, 504, 408)],
+        method_whitelist=retry_methods
+    )
+    adapter = requests.adapters.HTTPAdapter(max_retries=retry)
+    return adapter
+
+
+def _create_zegami_session(self):
+    """Create a session object to centrally handle auth and retry policy."""
     s = requests.Session()
     s.headers.update({
         'Authorization': 'Bearer {}'.format(self.token),
         'Content-Type': 'application/json',
     })
+
+    # Set up retry policy. Retry post requests as well as the usual methods.
+    adapter = __get_retry_adapter()
+    s.mount('http://', adapter)
+    s.mount('https://', adapter)
+
+    self._zegami_session = s
+
+
+def _create_blobstore_session(self):
+    """Session object to centrally handle retry policy."""
+    s = requests.Session()
+    adapter = __get_retry_adapter()
+    s.mount('https://', adapter)
+
+    self._blobstore_session = s
 
 
 def _ensure_token(self, username, password, token, allow_save_token):
@@ -87,7 +118,7 @@ def _auth_get(self, url, return_response=False, **kwargs):
 
     Any additional kwargs are forwarded onto the requests.get().
     """
-    r = self._session.get(url, **kwargs)
+    r = self._zegami_session.get(url, **kwargs)
     self._check_status(r, is_async_request=False)
     return r if return_response else r.json()
 
@@ -97,7 +128,7 @@ def _auth_delete(self, url, **kwargs):
 
     Any additional kwargs are forwarded onto the requests.delete().
     """
-    resp = self._session.delete(url, **kwargs)
+    resp = self._zegami_session.delete(url, **kwargs)
     self._check_status(resp, is_async_request=False)
     return resp
 
@@ -108,7 +139,7 @@ def _auth_post(self, url, body, return_response=False, **kwargs):
     its .json() output.
     Any additional kwargs are forwarded onto the requests.post().
     """
-    r = self._session.post(url, body, **kwargs)
+    r = self._zegami_session.post(url, body, **kwargs)
     self._check_status(r, is_async_request=False)
     return r if return_response else r.json()
 
@@ -119,7 +150,7 @@ def _auth_put(self, url, body, return_response=False, **kwargs):
     its .json() output.
     Any additional kwargs are forwarded onto the requests.put().
     """
-    r = self._session.put(url, body, **kwargs)
+    r = self._zegami_session.put(url, body, **kwargs)
     self._check_status(r, is_async_request=False)
     return r if return_response else r.json()
 
@@ -139,7 +170,7 @@ def _obtain_signed_blob_storage_urls(self, workspace_id, id_count=1):
     return urls, id_set
 
 
-def _upload_to_signed_blob_storage_url(data, url, mime_type, headers=None, **kwargs):
+def _upload_to_signed_blob_storage_url(self, data, url, mime_type, **kwargs):
     """Upload data to an already obtained blob storage url."""
     if url.startswith("/"):
         url = f'https://storage.googleapis.com{url}'
@@ -148,5 +179,5 @@ def _upload_to_signed_blob_storage_url(data, url, mime_type, headers=None, **kwa
     # https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
     if 'windows.net' in url:
         headers['x-ms-blob-type'] = 'BlockBlob'
-    response = requests.put(url, data=data, headers=headers, **kwargs)
+    response = self._blobstore_session.put(url, data=data, headers=headers, **kwargs)
     assert response.ok

--- a/zegami_sdk/util.py
+++ b/zegami_sdk/util.py
@@ -11,6 +11,14 @@ import uuid
 
 import requests
 
+def _create_session(self):
+    """Create a session object to ensure auth token is included as appropriate."""
+    s = requests.Session()
+    s.headers.update({
+        'Authorization': 'Bearer {}'.format(self.token),
+        'Content-Type': 'application/json',
+    })
+
 
 def _ensure_token(self, username, password, token, allow_save_token):
     """Tries the various logical steps to ensure a login token is set.
@@ -79,7 +87,7 @@ def _auth_get(self, url, return_response=False, **kwargs):
 
     Any additional kwargs are forwarded onto the requests.get().
     """
-    r = requests.get(url, headers=self.headers, **kwargs)
+    r = self._session.get(url, **kwargs)
     self._check_status(r, is_async_request=False)
     return r if return_response else r.json()
 
@@ -89,7 +97,7 @@ def _auth_delete(self, url, **kwargs):
 
     Any additional kwargs are forwarded onto the requests.delete().
     """
-    resp = requests.delete(url, headers=self.headers, **kwargs)
+    resp = self._session.delete(url, **kwargs)
     self._check_status(resp, is_async_request=False)
     return resp
 
@@ -100,7 +108,7 @@ def _auth_post(self, url, body, return_response=False, **kwargs):
     its .json() output.
     Any additional kwargs are forwarded onto the requests.post().
     """
-    r = requests.post(url, body, headers=self.headers, **kwargs)
+    r = self._session.post(url, body, **kwargs)
     self._check_status(r, is_async_request=False)
     return r if return_response else r.json()
 
@@ -111,7 +119,7 @@ def _auth_put(self, url, body, return_response=False, **kwargs):
     its .json() output.
     Any additional kwargs are forwarded onto the requests.put().
     """
-    r = requests.put(url, body, headers=self.headers, **kwargs)
+    r = self._session.put(url, body, **kwargs)
     self._check_status(r, is_async_request=False)
     return r if return_response else r.json()
 


### PR DESCRIPTION
Make requests to the API and to blob storage through a session. This has the following benefits:
* Cleaner way to manage adding the auth token header
* Retry behaviour can be centrally managed

Also tweak some of the upload images behaviour so that non-images are ignored rather than throwing an error (but see also https://zegami.atlassian.net/browse/ZGM-7567)

