### PR TITLE
Allow target any zegami instance

### DIFF
--- a/zegami_sdk/client.py
+++ b/zegami_sdk/client.py
@@ -15,10 +15,13 @@ from .util import (
     _create_blobstore_session,
     _ensure_token,
     _get_token,
+    _get_token_name,
     _check_status,
     _obtain_signed_blob_storage_urls,
     _upload_to_signed_blob_storage_url
 )
+
+DEFAULT_HOME = 'https://zegami.com'
 
 
 class ZegamiClient():
@@ -36,7 +39,6 @@ class ZegamiClient():
     controllers to browse data from.
     """
 
-    TOKEN_NAME = 'zegami.token'
     HOME = 'https://zegami.com'
     API_0 = 'api/v0'
     API_1 = 'api/v1'
@@ -48,15 +50,17 @@ class ZegamiClient():
     _create_zegami_session = _create_zegami_session
     _create_blobstore_session = _create_blobstore_session
     _ensure_token = _ensure_token
-    _get_token = classmethod(_get_token)
+    _get_token_name = _get_token_name
+    _get_token = _get_token
     _check_status = staticmethod(_check_status)
     _obtain_signed_blob_storage_urls = _obtain_signed_blob_storage_urls
     _upload_to_signed_blob_storage_url = _upload_to_signed_blob_storage_url
     _zegami_session = None
     _blobstore_session = None
 
-    def __init__(self, username=None, password=None, token=None, allow_save_token=True):
+    def __init__(self, username=None, password=None, token=None, allow_save_token=True, home=DEFAULT_HOME):
         # Make sure we have a token
+        self.HOME = home
         self._ensure_token(username, password, token, allow_save_token)
 
         # Initialise a requests session
@@ -146,8 +150,5 @@ class ZegamiClient():
 
 class _ZegamiStagingClient(ZegamiClient):
 
-    TOKEN_NAME = 'staging.zegami.token'
-    HOME = 'https://staging.zegami.com'
-
-    def __init__(self, username=None, password=None, token=None, allow_save_token=True):
-        super().__init__(username, password, token, allow_save_token)
+    def __init__(self, username=None, password=None, token=None, allow_save_token=True, home='https://staging.zegami.com'):
+        super().__init__(username, password, token, allow_save_token, home=home)

--- a/zegami_sdk/test.py
+++ b/zegami_sdk/test.py
@@ -44,12 +44,6 @@ class TestHelper(unittest.TestCase):
         )
 
 
-class TestZegamiClientMock(ZegamiClient):
-
-    TOKEN_NAME = 'mock.zegami.token'
-    HOME = 'https://mockzegami.com'
-
-
 class TestSdkUtil(unittest.TestCase):
 
     @requests_mock.Mocker()
@@ -59,8 +53,8 @@ class TestSdkUtil(unittest.TestCase):
         super().setUp()
         self.username = 'testUser'
         self.password = 'passWord'
-        self.local_token_path = os.path.join(Path.home(), 'mock.zegami.token')
-        self.url = TestZegamiClientMock(username=self.username, password=self.password)
+        self.local_token_path = os.path.join(Path.home(), 'mockzegami_com.zegami.token')
+        self.url = ZegamiClient(username=self.username, password=self.password, home="https://mockzegami.com")
 
     def tearDown(self):
         os.remove(self.local_token_path)

--- a/zegami_sdk/util.py
+++ b/zegami_sdk/util.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import uuid
 
 import requests
+from urllib.parse import urlparse
 import urllib3
 
 
@@ -51,6 +52,13 @@ def _create_blobstore_session(self):
     self._blobstore_session = s
 
 
+def _get_token_name(self):
+    url = urlparse(self.HOME)
+    netloc = url.netloc
+    prefix = netloc.replace('.', '_')
+    return f'{prefix}.zegami.token'
+
+
 def _ensure_token(self, username, password, token, allow_save_token):
     """Tries the various logical steps to ensure a login token is set.
 
@@ -58,7 +66,7 @@ def _ensure_token(self, username, password, token, allow_save_token):
     saved token files.
     """
     # Potential location of locally saved token
-    local_token_path = os.path.join(Path.home(), self.TOKEN_NAME)
+    local_token_path = os.path.join(Path.home(), self._get_token_name())
 
     if token:
         if os.path.exists(token):
@@ -83,10 +91,11 @@ def _ensure_token(self, username, password, token, allow_save_token):
                              'and no locally saved token was found.')
 
 
-def _get_token(ZC, username, password):
+def _get_token(self, username, password):
     """Gets the client's token using a username and password."""
 
-    url = '{}/oauth/token/'.format(ZC.HOME)
+    url = '{}/oauth/token/'.format(self.HOME)
+
     data = {'username': username, 'password': password, 'noexpire': True}
 
     r = requests.post(url, json=data)


### PR DESCRIPTION
Provide a new `home` argument which sets the home domain.
Save tokens for different domains under different token names.

This allows us to write e2e tests using the SDK targeting rollout.zegami.com, and also work with customer deployments e.g. onprem or on their own azure.

This change does mean existing saved tokens will cease to work, but that probably doesn't affect any actual users.
