### PR TITLE
Add an option to override the imageset id when downloading images

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import pathlib
 from setuptools import setup
 
 # Update version here when you want to increment the version in PyPi
-sdk_version = '0.4.1'
+sdk_version = '0.4.2'
 
 # If no ZEGAMI_SDK_VERSION set use the version
 try:

--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -279,7 +279,7 @@ class Collection():
             imageset_id = override_imageset_id
         else:
             imageset_id = self._get_imageset_id(source)
-            
+
         c = self.client
         if not generate_signed_urls:
             return ['{}/{}/project/{}/imagesets/{}/images/{}/data'.format(

--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -247,7 +247,7 @@ class Collection():
         rows = self.rows.iloc[list(row_indices)]
         return rows
 
-    def get_image_urls(self, rows, source=0, generate_signed_urls=False):
+    def get_image_urls(self, rows, source=0, generate_signed_urls=False, override_imageset_id=None):
         """Converts rows into their corresponding image URLs.
 
         If generate_signed_urls is false the URLs require a token to download
@@ -255,6 +255,9 @@ class Collection():
 
         If generate_signed_urls is true the urls can be used to fetch the images directly
         from blob storage, using a temporary access signature.
+
+        By default the uploaded images are fetched, but it's possible to fech e.g. the thumbnails
+        only, by providing an alternative imageset id.
         """
         # Turn the provided 'rows' into a list of ints
         if type(rows) == pd.DataFrame:
@@ -272,14 +275,19 @@ class Collection():
         imageset_indices = [lookup[i] for i in indices]
 
         # Convert these into URLs
+        if override_imageset_id is not None:
+            imageset_id = override_imageset_id
+        else:
+            imageset_id = self._get_imageset_id(source)
+            
         c = self.client
         if not generate_signed_urls:
             return ['{}/{}/project/{}/imagesets/{}/images/{}/data'.format(
-                c.HOME, c.API_0, self.workspace_id, self._get_imageset_id(source),
+                c.HOME, c.API_0, self.workspace_id, imageset_id,
                 i) for i in imageset_indices]
         else:
             get_signed_urls = ['{}/{}/project/{}/imagesets/{}/images/{}/signed_route'.format(
-                c.HOME, c.API_0, self.workspace_id, self._get_imageset_id(source),
+                c.HOME, c.API_0, self.workspace_id, imageset_id,
                 i
             ) for i in imageset_indices]
             signed_route_urls = []


### PR DESCRIPTION
This is needed by a user to fetch some scaled thumbnails which were produced by adding a new node to the graph.