### PR TITLE
Allow insecure requests via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,33 @@ first_10_source3_img_urls = novo_col.get_image_urls(list(range(10)), source=2)`
 coll.download_image(first_10_source3_img_urls[0])
 ```
 
+### Using with onprem zegami
+
+To use the client with an onprem installation of zegami you have to set the `home` keyword argument when instantiating `ZegamiClient`.
+
+```
+zegami_config = {
+  'username': <user>,
+  'password': <password>,
+  'home': <url of onprem zegami>,
+  'allow_save_token': True,
+}
+
+zc = ZegamiClient(**zegami_config)
+```
+
+If your onprem installation has self-signed certificates you can disable SSL verification using the environment variable `ALLOW_INSECURE_SSL` before running the python.
+
+```
+export ALLOW_INSECURE_SSL=true
+python myscript.py
+```
+or
+```
+ALLOW_INSECURE_SSL=true python myscript.py
+```
+WARNING! You should not need to set this when using the SDK for cloud zegami
+
 # In Development
 This SDK is in active development, not all features are available yet. Creating/uploading to collections is not supported currently - check back soon!
 

--- a/zegami_sdk/test.py
+++ b/zegami_sdk/test.py
@@ -5,6 +5,7 @@
 """SDK Integration Authentication tests."""
 
 import io
+import importlib
 import os
 from pathlib import Path
 import sys
@@ -74,9 +75,11 @@ class TestSdkUtil(unittest.TestCase):
             self.assertNotEqual(os.path.getsize(self.local_token_path), 0)
 
 
-@unittest.mock.patch.dict(os.environ, {'ALLOW_INSECURE_SSL': 'True'})
+@unittest.mock.patch.dict(os.environ, {'ALLOW_INSECURE_SSL': 'yes'})
 class TestSdkUtilVerifySSLFalse(TestSdkUtil):
 
-    @unittest.mock.patch.dict(os.environ, {'ALLOW_INSECURE_SSL': 'True'})
-    def setUp(self):
-        return super().setUp()
+    @classmethod
+    @unittest.mock.patch.dict(os.environ, {'ALLOW_INSECURE_SSL': 'yes'})
+    def setUpClass(self):
+        importlib.reload(util)
+        return super().setUpClass()

--- a/zegami_sdk/test.py
+++ b/zegami_sdk/test.py
@@ -72,3 +72,11 @@ class TestSdkUtil(unittest.TestCase):
                 token=None, allow_save_token=True
             )
             self.assertNotEqual(os.path.getsize(self.local_token_path), 0)
+
+
+@unittest.mock.patch.dict(os.environ, {'ALLOW_INSECURE_SSL': 'True'})
+class TestSdkUtilVerifySSLFalse(TestSdkUtil):
+
+    @unittest.mock.patch.dict(os.environ, {'ALLOW_INSECURE_SSL': 'True'})
+    def setUp(self):
+        return super().setUp()


### PR DESCRIPTION
- Allow requests to set `verify=False` for insecure/self-signed SSL
- Default to verify SSL properly unless environment variable is set