### PR TITLE
Fix checking response success

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import pathlib
 from setuptools import setup
 
 # Update version here when you want to increment the version in PyPi
-sdk_version = '0.4.3'
+sdk_version = '0.4.4'
 
 # If no ZEGAMI_SDK_VERSION set use the version
 try:

--- a/zegami_sdk/util.py
+++ b/zegami_sdk/util.py
@@ -117,12 +117,12 @@ def _check_status(response, is_async_request=False):
 
     If allow is set to True, doesn't throw an exception.
     """
-    code = response.status if is_async_request else response.status_code
-    response_message = 'Bad request response ({}): {}\n\nbody:\n{}'.format(
-        code, response.reason, response.text
-    )
-
-    assert response.ok, response_message
+    if not response.ok:
+        code = response.status if is_async_request else response.status_code
+        response_message = 'Bad request response ({}): {}\n\nbody:\n{}'.format(
+            code, response.reason, response.text
+        )
+        raise AssertionError(response_message)
 
 
 def _auth_get(self, url, return_response=False, **kwargs):


### PR DESCRIPTION
Referencing response.text consumes the response body, so only do it here if the response is an error.

Fixes one source of the current hourly failures.