### PR TITLE
Restructure/Reformat

### DIFF
--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -1003,14 +1003,19 @@ class Collection():
         annos = self.get_annotations(
             anno_type=anno_type, source=source)
 
+        classes = self.classes
+
         def to_dict(a):
-            d = {
-                'Row Index': self.imageset_index_to_row_index(a['image_index']),
-                'ID': a['id'],
-                'Type': a['type'],
-                'Author': a['author'],
-                'Imageset Index': a['image_index'],
-            }
+            d = {}
+            if classes and 'class_id' in a.keys():
+                c = next(filter(lambda c: c['id'] == a['class_id'], classes))
+                d['Class'] = c['name']
+                d['Class ID'] = c['id']
+            d['Type'] = a['type']
+            d['Author'] = a['author']
+            d['Row Index'] = self.imageset_index_to_row_index(a['image_index'])
+            d['Imageset Index'] = a['image_index']
+            d['ID'] = a['id']
             if 'metadata' in a.keys():
                 for k, v in a['metadata'].items():
                     d[k] = v

--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -736,26 +736,31 @@ class Collection():
 
         return r
 
-    def delete_all_annotations(self, source=0):
-        """Deletes all annotations saved to the collection."""
+    def delete_all_annotations(self, only_for_source=None):
+        """
+        Deletes all annotations saved to the collection. By default this
+        operation deletes all annotations from all sources. Provide a
+        specific source (instance or index) to limit this to a particular
+        source.
+        """
 
-        # A list of sources of annotations
-        anno_sources = self.get_annotations()['sources']
+        # Get the sources to delete annotations from
+        scoped_sources = self.sources if only_for_source is None\
+            else [self._parse_source(only_for_source)]
 
         c = 0
-        for i, source in enumerate(anno_sources):
+        for source in scoped_sources:
 
-            # A list of annotation objects
-            annotations = source['annotations']
-            if len(annotations) == 0:
+            annos = self.get_annotations(source=source)
+            if len(annos) == 0:
                 continue
 
             print('Deleting {} annotations from source {}'
-                  .format(len(annotations), i))
+                  .format(len(annos), source.name))
 
-            for j, annotation in enumerate(annotations):
-                self.delete_annotation(annotation['id'])
-                print('\r{}/{}'.format(j + 1, len(annotations)), end='',
+            for j, anno in enumerate(annos):
+                self.delete_annotation(anno['id'])
+                print('\r{}/{}'.format(j + 1, len(annos)), end='',
                       flush=True)
                 c += 1
             print('')

--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -1008,9 +1008,9 @@ class Collection():
         def to_dict(a):
             d = {}
             if classes and 'class_id' in a.keys():
-                c = next(filter(lambda c: c['id'] == a['class_id'], classes))
+                c = next(filter(lambda c: int(c['id']) == int(a['class_id']), classes))
                 d['Class'] = c['name']
-                d['Class ID'] = c['id']
+                d['Class ID'] = int(c['id'])
             d['Type'] = a['type']
             d['Author'] = a['author']
             d['Row Index'] = self.imageset_index_to_row_index(a['image_index'])

--- a/zegami_sdk/source.py
+++ b/zegami_sdk/source.py
@@ -11,20 +11,19 @@ from tqdm import tqdm
 
 
 class Source():
+    """
+    A data structure representing information about a subset of a collection.
+    V1 collections have one source, V2+ can contain multiple each with their
+    own imagesets.
+    """
+
+    def __repr__(self):
+        return '<Source "{}" from Collection "{}", id: "{}"'.format(
+            self.name, self.collection.name, self.id)
 
     def __init__(self, collection, source_dict):
         self._collection = collection
         self._data = source_dict
-
-    @property
-    def name():
-        pass
-
-    @name.getter
-    def name(self):
-        assert self._data, 'Source had no self._data set'
-        assert 'name' in self._data.keys(), 'Source\'s data didn\'t have a \'name\' key'
-        return self._data['name']
 
     @property
     def collection():
@@ -35,14 +34,24 @@ class Source():
         return self._collection
 
     @property
+    def name():
+        pass
+
+    @name.getter
+    def name(self):
+        return self._retrieve('name')
+
+    @property
     def id():
         pass
 
     @id.getter
     def id(self):
-        assert self._data, 'Source had no self._data set'
-        assert 'source_id' in self._data, 'Source\'s data didn\'t have a \'source_id\' key'
-        return self._data['source_id']
+        """The .source_id of this Source. Note: Invalid for V1 collections."""
+
+        if self.collection.version < 2:
+            return None
+        return self._retrieve('source_id')
 
     @property
     def imageset_id():
@@ -50,9 +59,19 @@ class Source():
 
     @imageset_id.getter
     def imageset_id(self):
-        assert self._data, 'Source had no self._data set'
-        assert 'imageset_id' in self._data, 'Source\'s data didn\'t have an \'imageset_id\' key'
-        return self._data['imageset_id']
+        return self._retrieve('imageset_id')
+
+    @property
+    def index():
+        pass
+
+    @index.getter
+    def index(self) -> int:
+        """
+        The index/position of this source in its collection's .sources list.
+        """
+
+        return self.collection.sources.index(self)
 
     @property
     def _imageset_dataset_join_id():
@@ -60,10 +79,12 @@ class Source():
 
     @_imageset_dataset_join_id.getter
     def _imageset_dataset_join_id(self):
-        k = 'imageset_dataset_join_id'
-        assert self._data, 'Source had no self._data set'
-        assert k in self._data, 'Source\'s data didn\'t have an \'{}\' key'.format(k)
-        return self._data[k]
+        return self._retrieve('imageset_dataset_join_id')
+
+    def _retrieve(self, key):
+        if key not in self._data:
+            raise KeyError('Key "{}" not found in Source _data'.format(key))
+        return self._data[key]
 
 
 class UploadableSource():

--- a/zegami_sdk/workspace.py
+++ b/zegami_sdk/workspace.py
@@ -65,7 +65,7 @@ class Workspace():
         if not collection_dicts:
             return []
         collection_dicts = collection_dicts['collections']
-        return [Collection._construct_collection(c, self, d) for d in collection_dicts]
+        return [Collection(c, self, d) for d in collection_dicts]
 
     def get_collection_by_name(self, name) -> Collection:
         """Obtains a collection by name (case-insensitive)."""


### PR DESCRIPTION
- No longer uses Collection, CollectionV2, or a `_construct_collection` method.
- All methods in the regular Collection class support V1/V2, filling in gaps from before this change.
- Collections no longer rebuild `Source()`s every time you check `.sources`. Built once on construction and that's it.
- `get_annotations` now works consistently and returns a list of annotations, no more searching through sources or having to dig into the results `['annotations']`.
- Cut down and simplified unnecessary code for fetching various _data entries and redundant checks.
- Moved a couple of methods orders around (keeping __repr__, __len__ at top, etc.).
- Docstring/formatting

Tested getting annotations from V1 and V2 collections, works now as it didn't before. **Very likely that tests need to be updated.**