### PR TITLE
Fix functionality for adding images to an existing collection

### DIFF
--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -863,9 +863,9 @@ class Collection():
             for s in uploadable_sources:
                 s._check_in_data(data)
 
-        # append rows to data
-        new_rows = self.rows.append(data)
-        self.replace_data(new_rows)
+            # append rows to data
+            new_rows = self.rows.append(data)
+            self.replace_data(new_rows)
 
         # validate and register uploadable sources against existing sources
         for s in uploadable_sources:


### PR DESCRIPTION
Don't replace data if none is provided
Calculate start index correctly when generating workloads. Previously it was overwriting image info from the start of the imageset, not at the point the array was extended.