### PR TITLE
Fix collection creation issues

### DIFF
--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -1088,9 +1088,9 @@ class Collection():
             self.replace_data(new_rows)
 
         # validate and register uploadable sources against existing sources
-        for s in uploadable_sources:
-            for i, us in enumerate(uploadable_sources):
-                us._register_source(i, self.sources[i])
+        for i, us in enumerate(uploadable_sources):
+            us._register_source(i, self.sources[i])
+            
 
         # upload
         for us in uploadable_sources:

--- a/zegami_sdk/collection.py
+++ b/zegami_sdk/collection.py
@@ -1090,7 +1090,6 @@ class Collection():
         # validate and register uploadable sources against existing sources
         for i, us in enumerate(uploadable_sources):
             us._register_source(i, self.sources[i])
-            
 
         # upload
         for us in uploadable_sources:

--- a/zegami_sdk/source.py
+++ b/zegami_sdk/source.py
@@ -198,7 +198,7 @@ class UploadableSource():
         self._index = index
         self._source = source
 
-        if not self.source.name == self.name:
+        if not self.source.name == 'None' and not self.source.name == self.name:
             raise Exception(
                 'UploadableSource "{}" registered to Source "{}" when their names should match'
                 .format(self.name, self.source.name)

--- a/zegami_sdk/source.py
+++ b/zegami_sdk/source.py
@@ -114,7 +114,7 @@ class UploadableSource():
         ".json"
     )
 
-    def __init__(self, name, image_dir, column_filename='Filename', recursive_search=True):
+    def __init__(self, name, image_dir, column_filename='__auto_join__', recursive_search=True):
         """Used in conjunction with create_collection().
 
         An UploadableSource() points towards and manages the upload of local files, resulting in the
@@ -328,7 +328,7 @@ class UploadableSource():
 
     def _check_in_data(self, data):
         cols = list(data.columns)
-        if self.column_filename not in cols:
+        if self.column_filename != '__auto_join__' and self.column_filename not in cols:
             raise Exception('Source "{}" had the filename_column "{}" '
                             'which is not a column of the provided data:\n{}'
                             .format(self.name, self.column_filename, cols))
@@ -363,7 +363,7 @@ class UploadableSource():
 
 class UrlSource(UploadableSource):
 
-    def __init__(self, name, url_template, image_fetch_headers, column_filename='Filename'):
+    def __init__(self, name, url_template, image_fetch_headers, column_filename=None):
         """Used in conjunction with create_collection().
 
         A UrlSource() fetches the images from the url template given, resulting in the

--- a/zegami_sdk/workspace.py
+++ b/zegami_sdk/workspace.py
@@ -166,7 +166,7 @@ class Workspace():
         post_data = {
             'name': name,
             'description': description,
-            'image_sources': [{'name': s.name} for s in uploadable_sources],
+            'image_sources': [{'name': s.name, 'dataset_column': s.column_filename} for s in uploadable_sources],
             **kwargs
         }
 


### PR DESCRIPTION
- We use source name `None` for v1 collection so should not check name in `register_source`
- Include `dataset_column` with provided `column_filename` in v2 image_sources, use '__auto_join__` by default